### PR TITLE
FEAT: BE-02: Add initial immunization database migrations

### DIFF
--- a/backend/database/migrations/1752251579912_create_facilities_table.ts
+++ b/backend/database/migrations/1752251579912_create_facilities_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'facilities'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable()
+      table.string('district').notNullable()
+      table.string('address')
+      table.string('contact_phone')
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251610173_create_patients_table.ts
+++ b/backend/database/migrations/1752251610173_create_patients_table.ts
@@ -1,0 +1,32 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'patients'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('full_name').notNullable()
+      table.enum('sex', ['M', 'F']).notNullable()
+      table.date('date_of_birth').notNullable()
+      table.string('mother_name')
+      table.string('father_name')
+      table.string('district').notNullable()
+      table.string('town_village')
+      table.string('address')
+      table.string('contact_phone')
+      table.integer('health_worker_id').unsigned().references('id').inTable('users').onDelete('SET NULL')
+      table.string('health_worker_name')
+      table.string('health_worker_phone')
+      table.string('health_worker_address')
+      table.integer('facility_id').unsigned().references('id').inTable('facilities').notNullable()
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251639547_create_vaccines_table.ts
+++ b/backend/database/migrations/1752251639547_create_vaccines_table.ts
@@ -1,0 +1,26 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'vaccines'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable()
+      table.string('description')
+      table.string('vaccine_code').notNullable() // Standardized codes (e.g., "BCG", "OPV0")
+      table.integer('sequence_number').nullable() // Dose number in a series
+      table.string('vaccine_series').nullable() // Group related vaccines (e.g., "OPV", "Penta")
+      table.string('standard_schedule_age').nullable() // Recommended administration age
+      table.boolean('is_supplementary').defaultTo(false) // Distinguish between standard and supplementary
+      table.boolean('is_active').defaultTo(true)
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251676660_create_immunization_records_table.ts
+++ b/backend/database/migrations/1752251676660_create_immunization_records_table.ts
@@ -1,0 +1,29 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'immunization_records'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.integer('patient_id').unsigned().references('id').inTable('patients').onDelete('CASCADE')
+      table.integer('vaccine_id').unsigned().references('id').inTable('vaccines').onDelete('CASCADE')
+      table.date('administered_date').notNullable()
+      table.integer('administered_by_user_id').unsigned().references('id').inTable('users')
+      table.string('health_officer').nullable() // Who administered the vaccine
+      table.integer('facility_id').unsigned().references('id').inTable('facilities')
+      table.string('batch_number')
+      table.date('return_date')
+      table.boolean('is_standard_schedule').defaultTo(true) // If part of standard schedule
+      table.enum('schedule_status', ['on_schedule', 'delayed', 'missed']).nullable() // Track compliance with schedule
+      table.text('notes')
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251710420_create_notifications_table.ts
+++ b/backend/database/migrations/1752251710420_create_notifications_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'notifications'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.integer('patient_id').unsigned().references('id').inTable('patients').onDelete('CASCADE')
+      table.integer('vaccine_id').unsigned().references('id').inTable('vaccines').onDelete('CASCADE')
+      table.date('due_date').notNullable()
+      table.enum('status', ['pending', 'viewed', 'completed', 'overdue']).defaultTo('pending')
+      table.integer('facility_id').unsigned().references('id').inTable('facilities')
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251744833_create_vaccine_schedules_table.ts
+++ b/backend/database/migrations/1752251744833_create_vaccine_schedules_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'vaccine_schedules'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable() // e.g., "Liberia EPI Schedule"
+      table.string('country').notNullable()
+      table.text('description')
+      table.boolean('is_active').defaultTo(true)
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251776858_create_vaccine_schedule_items_table.ts
+++ b/backend/database/migrations/1752251776858_create_vaccine_schedule_items_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'vaccine_schedule_items'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.integer('schedule_id').unsigned().references('id').inTable('vaccine_schedules').onDelete('CASCADE')
+      table.integer('vaccine_id').unsigned().references('id').inTable('vaccines').onDelete('CASCADE')
+      table.string('recommended_age').notNullable() // e.g., "At birth", "6 weeks"
+      table.boolean('is_required').defaultTo(true)
+      table.integer('sequence_in_schedule') // Order in the schedule
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1752251813981_create_supplementary_immunizations_table.ts
+++ b/backend/database/migrations/1752251813981_create_supplementary_immunizations_table.ts
@@ -1,0 +1,25 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'supplementary_immunizations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable()
+      table.text('description')
+      table.date('start_date').notNullable()
+      table.date('end_date').notNullable()
+      table.integer('facility_id').unsigned().references('id').inTable('facilities')
+      table.integer('vaccine_id').unsigned().references('id').inTable('vaccines')
+      table.text('target_population')
+      
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}


### PR DESCRIPTION
Introduces migrations for facilities, patients, vaccines, immunization records, notifications, vaccine schedules, schedule items, and supplementary immunizations. These tables establish the core schema for managing immunization data, scheduling, and notifications in the backend.