### PR TITLE
Increase default patient query limit to 999

### DIFF
--- a/backend/app/controllers/patients_controller.ts
+++ b/backend/app/controllers/patients_controller.ts
@@ -10,7 +10,7 @@ export default class PatientsController {
    */
   async index({ request, response }: HttpContext) {
     const page = request.input('page', 1)
-    const limit = request.input('limit', 20)
+    const limit = request.input('limit', 999)
     
     const patients = await Patient.query()
       .preload('facility')


### PR DESCRIPTION
Updated the default 'limit' parameter in the patients index controller from 20 to 999 to allow fetching more patient records per request.