### PR TITLE
Add facility selection for admin in PatientForm

### DIFF
--- a/frontend/app/(drawer)/admin/_layout.tsx
+++ b/frontend/app/(drawer)/admin/_layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Stack } from 'expo-router';
+import { Stack , Redirect } from 'expo-router';
 import { useAuth } from '../../../context/auth';
-import { Redirect } from 'expo-router';
 
 export default function AdminLayout() {
   const { user } = useAuth();

--- a/frontend/app/components/PatientForm.tsx
+++ b/frontend/app/components/PatientForm.tsx
@@ -3,9 +3,12 @@ import { View, Text, StyleSheet, ScrollView, TextInput, TouchableOpacity, Keyboa
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Ionicons } from '@expo/vector-icons';
+import { Picker } from '@react-native-picker/picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { format } from 'date-fns';
 import { PatientFormData, patientSchema } from '../../types/patient';
+import { useAuth } from '../../context/auth';
+import api from '../../services/api';
 
 interface PatientFormProps {
   initialData?: Partial<PatientFormData>;
@@ -20,11 +23,13 @@ export default function PatientForm({
   isLoading = false,
   submitButtonText = 'Save Patient',
 }: PatientFormProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'administrator';
+
   const {
     control,
     handleSubmit,
     formState: { errors },
-    watch,
     setValue,
   } = useForm<PatientFormData>({
     resolver: zodResolver(patientSchema),
@@ -40,12 +45,28 @@ export default function PatientForm({
       contactPhone: '',
       healthWorkerName: '',
       healthWorkerPhone: '',
+      facilityId: undefined,
       ...initialData,
     },
   });
 
   const [showDatePicker, setShowDatePicker] = React.useState(false);
-  const selectedDate = watch('dateOfBirth');
+  const [facilities, setFacilities] = React.useState<{ id: number; name: string }[]>([]);
+
+  // Fetch facilities if user is admin
+  React.useEffect(() => {
+    if (isAdmin) {
+      const fetchFacilities = async () => {
+        try {
+          const response = await api.get('/facilities');
+          setFacilities(response.data.data || []);
+        } catch (error) {
+          console.error('Failed to fetch facilities:', error);
+        }
+      };
+      fetchFacilities();
+    }
+  }, [isAdmin]);
 
   const handleDateChange = (event: any, selectedDate?: Date) => {
     setShowDatePicker(false);
@@ -244,6 +265,38 @@ export default function PatientForm({
           keyboardType="phone-pad"
           required
         />
+
+        {isAdmin && (
+          <View style={styles.formGroup}>
+            <Text style={styles.label}>Facility</Text>
+            <Controller
+              control={control}
+              name="facilityId"
+              render={({ field: { onChange, value } }) => (
+                <View style={[styles.input, errors.facilityId && styles.inputError]}>
+                  <Picker
+                    selectedValue={value}
+                    onValueChange={(itemValue) => onChange(itemValue)}
+                    enabled={!isLoading}
+                    style={styles.picker}
+                  >
+                    <Picker.Item label="Select Facility" value={undefined} />
+                    {facilities.map((facility) => (
+                      <Picker.Item
+                        key={facility.id}
+                        label={facility.name}
+                        value={facility.id}
+                      />
+                    ))}
+                  </Picker>
+                </View>
+              )}
+            />
+            {errors.facilityId && (
+              <Text style={styles.errorText}>{errors.facilityId.message}</Text>
+            )}
+          </View>
+        )}
       </View>
 
       <View style={styles.formSection}>
@@ -372,5 +425,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: '#fff',
+  },
+  picker: {
+    color: '#1a1a1a',
   },
 });

--- a/frontend/app/immunizations/[id]/edit.tsx
+++ b/frontend/app/immunizations/[id]/edit.tsx
@@ -16,8 +16,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
 
-import { immunizationSchema, ImmunizationFormData, ImmunizationRecord } from '../../../types/immunization';
-import { Vaccine } from '../../../types/immunization';
+import { immunizationSchema, ImmunizationFormData, ImmunizationRecord , Vaccine } from '../../../types/immunization';
 import { Patient } from '../../../types/patient';
 import { patientKeys } from '../../../hooks/usePatients';
 import api from '../../../services/api';

--- a/frontend/app/immunizations/add.tsx
+++ b/frontend/app/immunizations/add.tsx
@@ -16,8 +16,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
 
-import { immunizationSchema, ImmunizationFormData } from '../../types/immunization';
-import { Vaccine } from '../../types/immunization';
+import { immunizationSchema, ImmunizationFormData , Vaccine } from '../../types/immunization';
 import { Patient } from '../../types/patient';
 import api from '../../services/api';
 import VaccineSelector from '../components/VaccineSelector';


### PR DESCRIPTION
Admins can now select a facility when creating or editing a patient. Facility options are fetched from the API and displayed in a Picker. Also, minor import cleanups in immunization files.