### PR TITLE
Remove health worker fields from patient and immunization forms

### DIFF
--- a/backend/app/controllers/immunization_records_controller.ts
+++ b/backend/app/controllers/immunization_records_controller.ts
@@ -164,8 +164,6 @@ export default class ImmunizationRecordsController {
       'patientId',
       'vaccineId',
       'administeredDate',
-      'administeredByUserId',
-      'facilityId',
       'batchNumber',
       'returnDate',
       'notes'

--- a/backend/app/controllers/patients_controller.ts
+++ b/backend/app/controllers/patients_controller.ts
@@ -47,11 +47,7 @@ export default class PatientsController {
       'district',
       'townVillage',
       'address',
-      'contactPhone',
-      'healthWorkerId',
-      'healthWorkerName',
-      'healthWorkerPhone',
-      'healthWorkerAddress'
+      'contactPhone'
     ])
     
     // Set facility ID from authenticated user
@@ -84,10 +80,6 @@ export default class PatientsController {
       'townVillage',
       'address',
       'contactPhone',
-      'healthWorkerId',
-      'healthWorkerName',
-      'healthWorkerPhone',
-      'healthWorkerAddress',
       'facilityId'
     ])
     

--- a/backend/app/validators/immunization_record/update.ts
+++ b/backend/app/validators/immunization_record/update.ts
@@ -8,7 +8,6 @@ export const immunizationRecordUpdateValidator = vine.compile(
     patientId: vine.number().optional(),
     vaccineId: vine.number().optional(),
     administeredDate: vine.date().optional(),
-    administeredByUserId: vine.number().optional(),
     facilityId: vine.number().optional(),
     batchNumber: vine.string().trim().minLength(1).maxLength(50).optional(),
     returnDate: vine.date().optional(),

--- a/backend/app/validators/patient/store.ts
+++ b/backend/app/validators/patient/store.ts
@@ -13,10 +13,6 @@ export const patientStoreValidator = vine.compile(
     district: vine.string().trim().minLength(2).maxLength(100),
     townVillage: vine.string().trim().minLength(2).maxLength(100),
     address: vine.string().trim().minLength(5).maxLength(255),
-    contactPhone: vine.string().trim().minLength(5).maxLength(20),
-    healthWorkerId: vine.number().optional(),
-    healthWorkerName: vine.string().trim().minLength(2).maxLength(100).optional(),
-    healthWorkerPhone: vine.string().trim().minLength(5).maxLength(20).optional(),
-    healthWorkerAddress: vine.string().trim().minLength(5).maxLength(255).optional()
+    contactPhone: vine.string().trim().minLength(5).maxLength(20)
   })
 )

--- a/backend/app/validators/patient/update.ts
+++ b/backend/app/validators/patient/update.ts
@@ -14,10 +14,6 @@ export const patientUpdateValidator = vine.compile(
     townVillage: vine.string().trim().minLength(2).maxLength(100).optional(),
     address: vine.string().trim().minLength(5).maxLength(255).optional(),
     contactPhone: vine.string().trim().minLength(5).maxLength(20).optional(),
-    healthWorkerId: vine.number().optional(),
-    healthWorkerName: vine.string().trim().minLength(2).maxLength(100).optional(),
-    healthWorkerPhone: vine.string().trim().minLength(5).maxLength(20).optional(),
-    healthWorkerAddress: vine.string().trim().minLength(5).maxLength(255).optional(),
     facilityId: vine.number().optional()
   })
 )

--- a/frontend/app/components/PatientForm.tsx
+++ b/frontend/app/components/PatientForm.tsx
@@ -43,8 +43,6 @@ export default function PatientForm({
       townVillage: '',
       address: '',
       contactPhone: '',
-      healthWorkerName: '',
-      healthWorkerPhone: '',
       facilityId: undefined,
       ...initialData,
     },
@@ -297,23 +295,6 @@ export default function PatientForm({
             )}
           </View>
         )}
-      </View>
-
-      <View style={styles.formSection}>
-        <Text style={styles.sectionTitle}>Health Worker Information</Text>
-        
-        <FormInput
-          name="healthWorkerName"
-          label="Health Worker Name"
-          placeholder="Enter health worker name"
-        />
-
-        <FormInput
-          name="healthWorkerPhone"
-          label="Health Worker Phone"
-          placeholder="Enter health worker phone"
-          keyboardType="phone-pad"
-        />
       </View>
 
       <TouchableOpacity

--- a/frontend/app/immunizations/[id]/edit.tsx
+++ b/frontend/app/immunizations/[id]/edit.tsx
@@ -45,7 +45,6 @@ export default function EditImmunizationScreen() {
       administeredDate: '',
       returnDate: null,
       batchNumber: '',
-      administeredBy: '',
       notes: '',
     },
   });
@@ -81,7 +80,6 @@ export default function EditImmunizationScreen() {
         administeredDate: immunizationRecord.administeredDate,
         returnDate: immunizationRecord.returnDate,
         batchNumber: immunizationRecord.batchNumber,
-        administeredBy: immunizationRecord.administeredBy.fullName,
         notes: immunizationRecord.notes || '',
       });
     }
@@ -97,7 +95,6 @@ export default function EditImmunizationScreen() {
         batchNumber: data.batchNumber,
         returnDate: data.returnDate,
         notes: data.notes,
-        // Note: administeredBy is not updated as per backend requirements
       };
       const response = await api.put(`/immunization-records/${id}`, updateData);
       return response.data;
@@ -265,26 +262,6 @@ export default function EditImmunizationScreen() {
           />
         </View>
 
-        {/* Administered By (Read-only) */}
-        <View style={styles.formGroup}>
-          <Text style={styles.label}>Administered By</Text>
-          <Controller
-            control={control}
-            name="administeredBy"
-            render={({ field: { value } }) => (
-              <View style={styles.inputContainer}>
-                <Ionicons name="person" size={20} color="#6c757d" style={styles.inputIcon} />
-                <TextInput
-                  style={[styles.input, styles.readOnlyInput]}
-                  value={value}
-                  placeholder="Administered by"
-                  editable={false}
-                />
-              </View>
-            )}
-          />
-          <Text style={styles.readOnlyNote}>This field cannot be edited</Text>
-        </View>
 
         {/* Notes */}
         <View style={styles.formGroup}>

--- a/frontend/app/immunizations/add.tsx
+++ b/frontend/app/immunizations/add.tsx
@@ -46,7 +46,6 @@ export default function AddImmunizationScreen() {
       administeredDate: new Date().toISOString().split('T')[0],
       returnDate: null,
       batchNumber: '',
-      administeredBy: '',
       notes: '',
     },
   });
@@ -294,31 +293,6 @@ export default function AddImmunizationScreen() {
           />
         </View>
 
-        {/* Administered By */}
-        <View style={styles.formGroup}>
-          <Text style={styles.label}>Administered By *</Text>
-          <Controller
-            control={control}
-            name="administeredBy"
-            render={({ field: { onChange, onBlur, value } }) => (
-              <View>
-                <View style={styles.inputContainer}>
-                  <Ionicons name="person" size={20} color="#6c757d" style={styles.inputIcon} />
-                  <TextInput
-                    style={[styles.input, errors.administeredBy && styles.errorInput]}
-                    onBlur={onBlur}
-                    onChangeText={onChange}
-                    value={value}
-                    placeholder="Enter health worker name"
-                  />
-                </View>
-                {errors.administeredBy && (
-                  <Text style={styles.errorText}>{errors.administeredBy.message}</Text>
-                )}
-              </View>
-            )}
-          />
-        </View>
 
         {/* Notes */}
         <View style={styles.formGroup}>

--- a/frontend/types/immunization.ts
+++ b/frontend/types/immunization.ts
@@ -7,7 +7,6 @@ export const immunizationSchema = z.object({
   administeredDate: z.string().min(1, 'Administered date is required'),
   returnDate: z.string().nullable().optional(),
   batchNumber: z.string().min(1, 'Batch number is required'),
-  administeredBy: z.string().min(1, 'Administered by is required'),
   notes: z.string().optional(),
 });
 

--- a/frontend/types/patient.ts
+++ b/frontend/types/patient.ts
@@ -16,11 +16,6 @@ export const patientSchema = z.object({
   contactPhone: z.string()
     .min(5, 'Contact phone must be at least 5 characters')
     .regex(/^\+?[0-9\s-()]+$/, 'Please enter a valid phone number'),
-  healthWorkerName: z.string().optional(),
-  healthWorkerPhone: z.string()
-    .regex(/^\+?[0-9\s-()]+$/, 'Please enter a valid phone number')
-    .optional()
-    .or(z.literal('')),
   facilityId: z.number().optional(),
 });
 


### PR DESCRIPTION
This commit removes health worker-related fields and logic from both backend and frontend patient and immunization record forms, controllers, and validation schemas. The change streamlines data models and UI by eliminating unused or unnecessary health worker information.